### PR TITLE
Capture bot membershipId in intercepted responses

### DIFF
--- a/bot-test/bot-test.js
+++ b/bot-test/bot-test.js
@@ -12,6 +12,13 @@ const sendSuccess = require('../utils').sendSuccess;
 let botTest = {};
 let testIdCounter = 1;
 
+// Load pre-registered tokens so we can get bot info
+var tokens = require('../tokens.json');
+if (!tokens) {
+    tokens = {};
+}
+
+
 botTest.middleware = function (req, res, next) {
 
     // Public resources
@@ -28,6 +35,17 @@ botTest.middleware = function (req, res, next) {
     }
 
     let botUnderTestEmail = req.app.locals.botUnderTestEmail
+    // The first time we see a request from the bot save its token
+    // so we can look up info about it later
+    if ((!req.app.locals.botActor) && (res.locals.person.emails[0] == botUnderTestEmail)) {
+        const auth = req.get("Authorization");
+        // Extract token -- no error checking since we already passed auth
+        const splitted = auth.match(/^Bearer\s([0-9a-zA-Z]*)$/);
+        // Retreive Person from token
+        const token = splitted[1];
+        req.app.locals.botActor = tokens[token];
+    }
+
     // Check if this is a test request that should generate bot requests 
     const botTestHeader = req.get("X-Bot-Responses");
     if (botTestHeader) {

--- a/storage/response-builder.js
+++ b/storage/response-builder.js
@@ -88,7 +88,23 @@ ResponseStorage.prototype.isTrackedResponse = function(response, body) {
         respObj.body = body;
         // Add the roomId which we'll use to correlate bot responses
         respObj.roomId = body.roomId;
-        respObj.membershipId = body.id;
+        // If the bot is in this room, store its membershipID
+        if (response.req.app.locals.botActor) {
+            const actor = response.req.app.locals.botActor;
+            if (body.roomId) {
+                const db = response.req.app.locals.datastore;
+                db.memberships.listMembershipsForRoom(actor, body.roomId, function (err, list) {
+                    if ((!err) && (list.length)) {
+                        for (var i=0; i<list.length; i++) {
+                            if (list[i].personId == actor.id) {
+                                respObj.membershipId = list[i].id;
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+        }
         return true;
     }
     return false;


### PR DESCRIPTION
In order to include bot requests that don't have our roomId we now store the membershipId of the bot in the room associated with the test input